### PR TITLE
Update 20200612-stream-executor-c-api.md

### DIFF
--- a/rfcs/20200612-stream-executor-c-api.md
+++ b/rfcs/20200612-stream-executor-c-api.md
@@ -206,8 +206,8 @@ typedef struct SE_StreamExecutor {
   // internals.
   void (*create_stream)(SE_Device* executor, SE_Stream*, TF_Status*);
 
-  // Deletes SE_Stream and deallocates any underlying resources.
-  void (*delete_stream)(SE_Device* executor, SE_Stream stream);
+  // Destroys SE_Stream and deallocates any underlying resources.
+  void (*destroy_stream)(SE_Device* executor, SE_Stream stream);
 
   // Causes dependent to not begin execution until other has finished its
   // last-enqueued work.
@@ -224,8 +224,8 @@ typedef struct SE_StreamExecutor {
   void (*create_event)(
       SE_Device* executor, TF_Event* event, TF_Status* status);
 
-  // Delete SE_Event and perform any platform-specific deallocation and cleanup of an event.
-  void (*delete_event)(
+  // Destroy SE_Event and perform any platform-specific deallocation and cleanup of an event.
+  void (*destroy_event)(
       SE_Device* executor, SE_Event event, TF_Status* status);
 
   // Requests the current status of the event from the underlying platform.
@@ -246,8 +246,8 @@ typedef struct SE_StreamExecutor {
   // internals.
   void (*create_timer)(SE_Device* executor, SE_Timer* timer, TF_Status* status);
 
-  // Deletes timer and deallocates timer resources on the underlying platform.
-  void (*delete_timer)(SE_Device* executor, SE_Timer timer);
+  // Destroy timer and deallocates timer resources on the underlying platform.
+  void (*destroy_timer)(SE_Device* executor, SE_Timer timer);
 
   // Records a start event for an interval timer.
   TF_BOOL (*start_timer)(
@@ -302,9 +302,9 @@ TF_CAPI_EXPORT SE_Platform* SE_NewPlatform(
      SE_PlatformId* id,
      int32_t visible_device_count,
      SE_Device* (*create_device)(SE_Options* options, TF_Status* status),
+     void (*destroy_device)(SE_Device* device),
      SE_StreamExecutor* (*create_stream_executor)(TF_Status* status),
-     void (*delete_device)(SE_Device* device),
-     void (*delete_stream_executor)(SE_StreamExecutor* stream_executor);
+     void (*destroy_stream_executor)(SE_StreamExecutor* stream_executor);
 );
 
 TF_CAPI_EXPORT void SE_RegisterPlatform(
@@ -324,7 +324,7 @@ TF_CAPI_EXPORT void SE_RegisterPlatform(
 
 ## Usage example
 
-Define functions that create and delete `SE_Device` and `SE_StreamExecutor`:
+Define functions that create and destroy `SE_Device` and `SE_StreamExecutor`:
 
 ```cpp
 SE_Device* create_device(SE_Options* options, TF_Status* status) {
@@ -339,12 +339,12 @@ SE_StreamExecutor* create_stream_executor(TF_Status* status) {
   ...
   return se;
 }
-void delete_device(SE_Device* device) {
-  -- delete device handle here --
+void destroy_device(SE_Device* device) {
+  -- destroy device handle here --
   ...
   delete device;
 }
-void delete_stream_executor(SE_StreamExecutor* stream_executor) {
+void destroy_stream_executor(SE_StreamExecutor* stream_executor) {
   delete stream_executor;
 }
 ```

--- a/rfcs/20200612-stream-executor-c-api.md
+++ b/rfcs/20200612-stream-executor-c-api.md
@@ -115,11 +115,11 @@ typedef struct SE_PlatformId {
 
 #define SE_PLATFORMID_STRUCT_SIZE TF_OFFSET_OF_END(SE_PlatformId, id)
 
-typedef struct SE_Timer {
+typedef struct SE_TimerFns {
  size_t struct_size;
  uint64_t (*nanoseconds)(SE_Timer timer);
  uint64_t (*microseconds)(SE_Timer timer);
-} SE_Timer;
+} SE_TimerFns;
 
 #define SE_TIMER_STRUCT_SIZE TF_OFFSET_OF_END(SE_Timer, microseconds)
 

--- a/rfcs/20200612-stream-executor-c-api.md
+++ b/rfcs/20200612-stream-executor-c-api.md
@@ -101,7 +101,7 @@ typedef SE_Timer_st* SE_Timer;
 typedef TF_Status* (*TF_StatusCallbackFn)(void*);
 
 #ifndef TF_BOOL_DEFINED
-#define TF_BOOL int8_t
+#define TF_BOOL unsigned char
 #endif // TF_BOOL_DEFINED
 
 #ifndef TF_OFFSET_OF_END


### PR DESCRIPTION
Defined a portable bool type TF_BOOL.
Added structure size macro definitions for each structure and updated usage examples.
Removed const qualifier for all struct_sizes so that it can be set after initialization.
Fixed typos where member functions are supposed to be member function pointers.
Fixed missing extern "C".
Fixed typos in SE_TimerFns.
Used stdint types where possible.
Added struct_size  to SE_PlatformId for API extensibility since it is a struct.
Changed SE_NewPlatform to take in SE_PlatformId by pointer since SE_PlatformId is a struct.
Added missing type to plugin_id_value.